### PR TITLE
fix: change type from 'number' to 'integer' for python type 'int'

### DIFF
--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -54,7 +54,7 @@ PY_TO_JSON_TYPES_MAP = {
     set: {"type": "array"},
     tuple: {"type": "array"},
     float: {"type": "number", "format": "float"},
-    int: {"type": "number", "format": "integer"},
+    int: {"type": "integer", "format": "integer"},
     bool: {"type": "boolean"},
     Enum: {"type": "string"},
 }


### PR DESCRIPTION
JSON schema property `type` supports values **'number'** and **'integer'**, so it can make a difference between values 2 and 2.15 and do validation properly.